### PR TITLE
Support for docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.env
+node_modules

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: Build and publish Docker image to GHCR
 on:
   push:
     tags:
-      - '*'   # Triggers whenever a new tag is created. Adjust as needed.
+      - 'v*'   # Triggers whenever a new tag is created. Adjust as needed.
 
 jobs:
   build-and-publish:
@@ -23,7 +23,7 @@ jobs:
         run: |
           # GITHUB_REPOSITORY looks like "OrgName/RepoName"
           # Convert it entirely to lowercase using Bash parameter expansion:
-          echo "REPO_LOWER=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+          echo "REPO_LOWER=${{ github.repository.toLowerCase() }}" >> $GITHUB_ENV
 
       - name: Log in to GHCR
         uses: docker/login-action@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,35 @@
+name: Build and publish Docker image to GHCR
+
+on:
+  push:
+    tags:
+      - '*'     # Triggers whenever a new tag is pushed. Adjust the pattern as needed.
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read        # Allows reading the repository contents
+      packages: write       # Allows pushing packages (Docker images) to GHCR
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile              # Path to your Dockerfile
+          push: true                      # Push the image after building
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,19 +3,27 @@ name: Build and publish Docker image to GHCR
 on:
   push:
     tags:
-      - '*'     # Triggers whenever a new tag is pushed. Adjust the pattern as needed.
+      - '*'   # Triggers whenever a new tag is created. Adjust as needed.
 
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read        # Allows reading the repository contents
-      packages: write       # Allows pushing packages (Docker images) to GHCR
+      contents: read
+      packages: write
 
     steps:
-      - name: Check out the repository
+      - name: Check out repository
         uses: actions/checkout@v3
+
+      # 1) Convert GitHub repo name to lowercase and export as env variable
+      - name: Convert repository name to lowercase
+        id: lowercase_repo
+        run: |
+          # GITHUB_REPOSITORY looks like "OrgName/RepoName"
+          # Convert it entirely to lowercase using Bash parameter expansion:
+          echo "REPO_LOWER=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
 
       - name: Log in to GHCR
         uses: docker/login-action@v2
@@ -24,12 +32,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # 2) Build and push using the lowercased repo name
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
-          file: ./Dockerfile              # Path to your Dockerfile
-          push: true                      # Push the image after building
+          file: ./Dockerfile
+          push: true
           tags: |
-            ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ghcr.io/${{ env.REPO_LOWER }}:latest
+            ghcr.io/${{ env.REPO_LOWER }}:${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,14 @@
-FROM node:22.14.0
-
-# Create and change to the app directory
+# Use a builder image to install dependencies and compile the application
+FROM node:22.14.0 AS builder
 WORKDIR /app
-
-# Copy package files to the container
 COPY package*.json ./
-
-# Install project dependencies
 RUN npm install
-
-# Copy remaining project files
 COPY . .
+
+# Use a smaller runtime image to run the application
+FROM node:22.14.0-slim
+WORKDIR /app
+COPY --from=builder /app .
 
 # Define the command to run your app using npm
 ENTRYPOINT ["npm", "run", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:22.14.0
+
+# Create and change to the app directory
+WORKDIR /app
+
+# Copy package files to the container
+COPY package*.json ./
+
+# Install project dependencies
+RUN npm install
+
+# Copy remaining project files
+COPY . .
+
+# Define the command to run your app using npm
+ENTRYPOINT ["npm", "run", "start"]


### PR DESCRIPTION
This adds support for building the project in docker, as well as a github action to build and upload to github's docker registry.

I added the lowercase part because of challenges of the org name, but your repo may not need this.